### PR TITLE
Remove the case when no pd version found

### DIFF
--- a/src/main/kotlin/com/github/shiraji/permissionsdispatcherplugin/actions/GeneratePMCodeAction.kt
+++ b/src/main/kotlin/com/github/shiraji/permissionsdispatcherplugin/actions/GeneratePMCodeAction.kt
@@ -109,9 +109,9 @@ class GeneratePMCodeAction : CodeInsightAction() {
                     "No PermissionsDispatcher dependency found",
                     "Please add PermissionsDispatcher dependency",
                     NotificationType.WARNING))
-        } else {
-            generatePMCode()
         }
+
+        generatePMCode()
     }
 
     private fun rebuildAction(e: AnActionEvent?) {


### PR DESCRIPTION
This is because some developer add PD dependency in some unique format.
Since I can't pick them all, at least this plugin let them generate the
code.

Close #43 