### PR TITLE
fix ImportPath

### DIFF
--- a/src/main/kotlin/com/github/shiraji/permissionsdispatcherplugin/handlers/GeneratePMCodeHandlerKt.kt
+++ b/src/main/kotlin/com/github/shiraji/permissionsdispatcherplugin/handlers/GeneratePMCodeHandlerKt.kt
@@ -4,6 +4,7 @@ import com.github.shiraji.permissionsdispatcherplugin.models.GeneratePMCodeModel
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.ImportPath
 
@@ -112,7 +113,7 @@ class GeneratePMCodeHandlerKt(model: GeneratePMCodeModel) : GeneratePMCodeHandle
 
     override fun addImport(import: String) {
         val psiFactory = KtPsiFactory(project)
-        val importDirective = psiFactory.createImportDirective(ImportPath(import))
+        val importDirective = psiFactory.createImportDirective(ImportPath(FqName(import), false))
         if (file.importDirectives.none { it.importPath == importDirective.importPath }) {
             file.importList?.add(importDirective)
         }


### PR DESCRIPTION
fix #75 

In Kotlin 1.1.2, ImportPath(String) was removed. Maybe ImportPath(FqName, Boolean) works fine.
https://github.com/JetBrains/kotlin/commit/babb3b557dbd11b41d1885eb0defc0d7e5609ad2#diff-75af61ffa546231c196398f21cc919c1